### PR TITLE
use compileJava task to generate jni headers

### DIFF
--- a/circe-checksum/build.gradle
+++ b/circe-checksum/build.gradle
@@ -28,18 +28,8 @@ dependencies {
     testImplementation depLibs.mockito
 }
 
-task generateJniHeaders(type: JavaCompile) {
-    ext {
-        javahOutputDir = "$buildDir/javahGenerated"
-    }
-    classpath = sourceSets.main.compileClasspath
-    destinationDir file("${buildDir}/javahGenerated")
-    source = sourceSets.main.java
-    options.compilerArgs += [
-            '-h', file("${buildDir}/javahGenerated"),
-    ]
-
-    options.annotationProcessorPath = configurations.annotationProcessor
+compileJava {
+    options.headerOutputDirectory = file("${buildDir}/javahGenerated")
 }
 
 jar {

--- a/circe-checksum/src/main/circe/build.gradle
+++ b/circe-checksum/src/main/circe/build.gradle
@@ -27,9 +27,9 @@ library {
 
     binaries.configureEach { CppBinary binary ->
         def compileTask = binary.compileTask.get()
-        compileTask.dependsOn project(':circe-checksum').generateJniHeaders
+        compileTask.dependsOn project(':circe-checksum').compileJava
         compileTask.includes.from("${Jvm.current().javaHome}/include",
-                                  project(':circe-checksum').generateJniHeaders.javahOutputDir)
+                                  project(':circe-checksum').compileJava.options.headerOutputDirectory)
 
         def osFamily = binary.targetPlatform.targetMachine.operatingSystemFamily
 

--- a/cpu-affinity/build.gradle
+++ b/cpu-affinity/build.gradle
@@ -33,18 +33,8 @@ dependencies {
     testAnnotationProcessor depLibs.lombok
 }
 
-task generateJniHeaders(type: JavaCompile) {
-    ext {
-        javahOutputDir = "$buildDir/javahGenerated"
-    }
-    classpath = sourceSets.main.compileClasspath
-    destinationDir file("${buildDir}/javahGenerated")
-    source = sourceSets.main.java
-    options.compilerArgs += [
-            '-h', file("${buildDir}/javahGenerated"),
-    ]
-
-    options.annotationProcessorPath = configurations.annotationProcessor
+compileJava {
+    options.headerOutputDirectory = file("${buildDir}/javahGenerated")
 }
 
 jar {

--- a/cpu-affinity/src/main/affinity/build.gradle
+++ b/cpu-affinity/src/main/affinity/build.gradle
@@ -25,9 +25,9 @@ plugins {
 library {
     binaries.configureEach { CppBinary binary ->
         def compileTask = binary.compileTask.get()
-        compileTask.dependsOn project(':cpu-affinity').generateJniHeaders
+        compileTask.dependsOn project(':cpu-affinity').compileJava
         compileTask.includes.from("${Jvm.current().javaHome}/include",
-                                  project(':cpu-affinity').generateJniHeaders.javahOutputDir)
+                                  project(':cpu-affinity').compileJava.options.headerOutputDirectory)
 
         def osFamily = binary.targetPlatform.targetMachine.operatingSystemFamily
 


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

Simplify java compilation in the gradle

### Changes

- changes to build.gradle in circe-checksum and cpu-affinity

Master Issue: #2817