### PR TITLE
Bookie retain state at restart

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/BookieStateManager.java
@@ -207,11 +207,6 @@ public class BookieStateManager implements StateManager {
     }
 
     @Override
-    public boolean isWritable() {
-        return bookieStatus.isInWritable();
-    }
-
-    @Override
     public boolean isAvailableForHighPriorityWrites() {
         return availableForHighPriorityWrites;
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/StateManager.java
@@ -48,12 +48,7 @@ public interface StateManager extends AutoCloseable {
      * Check is ReadOnly.
      */
     boolean isReadOnly();
-
-    /**
-     * Check is Writable.
-     */
-    boolean isWritable();
-
+    
     /**
      * Check is Running.
      */

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/RegistrationManager.java
@@ -97,17 +97,6 @@ public interface RegistrationManager extends AutoCloseable {
     boolean isBookieRegisteredReadonly(BookieId bookieId) throws BookieException;
 
     /**
-     * Checks if Bookie with the given BookieId is registered as readwrite Bookie.
-     *
-     * @param bookieId bookie id
-     * @return returns true if a bookie with bookieid is currently registered as
-     *          readwrite bookie.
-     * @throws BookieException
-     */
-    boolean isBookieRegisteredReadWrite(BookieId bookieId) throws BookieException;
-
-
-    /**
      * Write the cookie data, which will be used for verifying the integrity of the bookie environment.
      *
      * @param bookieId bookie id

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/discover/ZKRegistrationManager.java
@@ -629,22 +629,6 @@ public class ZKRegistrationManager implements RegistrationManager {
     }
 
     @Override
-    public boolean isBookieRegisteredReadWrite(BookieId bookieId) throws BookieException {
-        String regPath = bookieRegistrationPath + "/" + bookieId;
-        try {
-            return (null != zk.exists(regPath, false));
-        } catch (KeeperException e) {
-            log.error("ZK exception while checking registration ephemeral znodes for BookieId: {}", bookieId, e);
-            throw new MetadataStoreException(e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("InterruptedException while checking registration ephemeral znodes for BookieId: {}", bookieId,
-                    e);
-            throw new MetadataStoreException(e);
-        }
-    }
-
-    @Override
     public void addRegistrationListener(RegistrationListener listener) {
         listeners.add(listener);
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/NullMetadataBookieDriver.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/NullMetadataBookieDriver.java
@@ -188,11 +188,6 @@ public class NullMetadataBookieDriver implements MetadataBookieDriver {
         }
 
         @Override
-        public boolean isBookieRegisteredReadWrite(BookieId bookieId) {
-            return false;
-        }
-
-        @Override
         public void writeCookie(BookieId bookieId, Versioned<byte[]> cookieData) throws BookieException {
 
         }

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/StateManagerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/StateManagerTest.java
@@ -254,8 +254,6 @@ public class StateManagerTest extends BookKeeperClusterTestCase {
         assertTrue(stateManager1.isRegistered());
         // readOnly state is retained
         assertTrue(stateManager1.isReadOnly());
-        // ReadWrite state is retained
-        assertFalse(stateManager1.isWritable());
         stateManager1.close();
     }
 
@@ -279,19 +277,15 @@ public class StateManagerTest extends BookKeeperClusterTestCase {
         stateManager.registerBookie(true).get();
         // Its not in the readonly state
         assertFalse(stateManager.isReadOnly());
-        // Is in read-write mode
-        assertTrue(stateManager.isWritable());
         // close state manager
         stateManager.close();
         BookieStateManager stateManager1 = new BookieStateManager(conf, rm);
         // reinit state manager
         stateManager1.initState();
-        // Bookie registeration is retained
+        // Bookie registration is retained
         assertTrue(stateManager1.isRegistered());
         // readOnly state is retained
         assertFalse(stateManager1.isReadOnly());
-        // ReadWrite state is retained
-        assertTrue(stateManager1.isWritable());
         stateManager1.close();
     }
 }

--- a/metadata-drivers/etcd/src/main/java/org/apache/bookkeeper/metadata/etcd/EtcdRegistrationManager.java
+++ b/metadata-drivers/etcd/src/main/java/org/apache/bookkeeper/metadata/etcd/EtcdRegistrationManager.java
@@ -317,16 +317,6 @@ class EtcdRegistrationManager implements RegistrationManager {
         return msResult(getReadonlyFuture).getCount() > 0;
     }
 
-    @Override
-    public boolean isBookieRegisteredReadWrite(BookieId bookieId) throws BookieException {
-        CompletableFuture<GetResponse> getWritableFuture = kvClient.get(
-                ByteSequence.from(getWritableBookiePath(scope, bookieId), UTF_8),
-                GetOption.newBuilder()
-                        .withCountOnly(true)
-                        .build());
-        return msResult(getWritableFuture).getCount() > 0;
-    }
-
     public void writeCookie(BookieId bookieId, Versioned<byte[]> cookieData) throws BookieException {
         ByteSequence cookiePath = ByteSequence.from(getCookiePath(scope, bookieId), UTF_8);
         Txn txn = kvClient.txn();


### PR DESCRIPTION
Descriptions of the changes in this PR:

This is used for retaining the state of the bookie (readonly/ read-write) after the bookie restarts

Motivation
If the bookie is in the readonly state and the bookie restarts it moves to the read-write state which is an undesired behavior.

Changes
The bookie statemanager init state initializes the state from the metadata server if it exists for a given bookie
Tests that test the state manage init state